### PR TITLE
[Discussion] Add possibility to render charts to image.Image

### DIFF
--- a/imager.go
+++ b/imager.go
@@ -1,0 +1,10 @@
+package chart
+
+import "image"
+
+// Imager interface is implemented by renderers that want to expose the data
+// as the image.Image interface.
+type Imager interface {
+	// ToImage returns a image.Image
+	ToImage() image.Image
+}

--- a/raster_renderer.go
+++ b/raster_renderer.go
@@ -212,3 +212,8 @@ func (rr *rasterRenderer) ClearTextRotation() {
 func (rr *rasterRenderer) Save(w io.Writer) error {
 	return png.Encode(w, rr.i)
 }
+
+// ToImage implements the Imager interface method.
+func (rr *rasterRenderer) ToImage() image.Image {
+	return rr.i
+}


### PR DESCRIPTION
This pull request is not ready to merge, it is ment to be start of a conversation about what I want to accomplish with the change. I think this might be possible to implement in a much better way.

To me this library seems focused on rendering through a web server, eg. writing .png files to a response writer to render. I think it would be nice to have the option to render to a image.Image (https://golang.org/pkg/image/) to be able to use the library in other ways. My current use case is a GUI application using shiny (https://github.com/golang/exp/tree/master/shiny) where it is easy to use image.Image to render in the application.

What are your thoughts on this? Is it something you would like to see in the library? If so, do you have a better approach to do this than mine? I have basically just duplicated the Render method, should be a more DRY way of doing this, but it might need some refactorings though.

If this is something you would like to see in the library and want help with it I'm more than happy to help with the implementation!