### PR TITLE
Correct calculated height of bar chart

### DIFF
--- a/bar_chart.go
+++ b/bar_chart.go
@@ -362,7 +362,7 @@ func (bc BarChart) getAdjustedCanvasBox(r Renderer, canvasBox Box, yrange Range,
 				lines := Text.WrapFit(r, bar.Label, barLabelBox.Width(), axisStyle)
 				linesBox := Text.MeasureLines(r, lines, axisStyle)
 
-				xaxisHeight = Math.MaxInt(linesBox.Height()+(2*DefaultXAxisMargin), xaxisHeight)
+				xaxisHeight = Math.MinInt(linesBox.Height()+(2*DefaultXAxisMargin), xaxisHeight)
 			}
 		}
 


### PR DESCRIPTION
When using a multi-line label on a bar chart, the total height of the chart box is miscalculated causing the bar labels to render outside of the chart canvas.

This pull request fixes this by correctly growing the canvas by using `math.MinInt` instead of `math.MaxInt`.