### PR TITLE
Fix multi-line bar chart label positioning

### DIFF
--- a/draw.go
+++ b/draw.go
@@ -288,7 +288,7 @@ func (d draw) TextWithin(r Renderer, text string, box Box, style Style) {
 			ty = y
 		}
 
-		d.Text(r, line, tx, ty, style)
+		r.Text(line, tx, ty)
 		y += lineBox.Height() + style.GetTextLineSpacing()
 	}
 }


### PR DESCRIPTION
When using a multi-line label in a bar chart the text is rendered via `draw` instead of directly to the renderer. Because of this the style of the renderer is reset after drawing the first line (which causes alignment issues due to `MeasureText` returning a zero value `Box`).
This PR fixes this by calling the renderer directly.