### PR TITLE
Fix func name typo in examples

### DIFF
--- a/_examples/linear_regression/main.go
+++ b/_examples/linear_regression/main.go
@@ -16,8 +16,8 @@ func drawChart(res http.ResponseWriter, req *http.Request) {
 
 	mainSeries := chart.ContinuousSeries{
 		Name:    "A test series",
-		XValues: seq.Range(1.0, 100.0),                 //generates a []float64 from 1.0 to 100.0 in 1.0 step increments, or 100 elements.
-		YValues: seq.RandomValuesWithAverage(100, 100), //generates a []float64 randomly from 0 to 100 with 100 elements.
+		XValues: seq.Range(1.0, 100.0),             //generates a []float64 from 1.0 to 100.0 in 1.0 step increments, or 100 elements.
+		YValues: seq.RandomValuesWithMax(100, 100), //generates a []float64 randomly from 0 to 100 with 100 elements.
 	}
 
 	// note we create a LinearRegressionSeries series by assignin the inner series.

--- a/_examples/poly_regression/main.go
+++ b/_examples/poly_regression/main.go
@@ -16,8 +16,8 @@ func drawChart(res http.ResponseWriter, req *http.Request) {
 
 	mainSeries := chart.ContinuousSeries{
 		Name:    "A test series",
-		XValues: seq.Range(1.0, 100.0),                 //generates a []float64 from 1.0 to 100.0 in 1.0 step increments, or 100 elements.
-		YValues: seq.RandomValuesWithAverage(100, 100), //generates a []float64 randomly from 0 to 100 with 100 elements.
+		XValues: seq.Range(1.0, 100.0),             //generates a []float64 from 1.0 to 100.0 in 1.0 step increments, or 100 elements.
+		YValues: seq.RandomValuesWithMax(100, 100), //generates a []float64 randomly from 0 to 100 with 100 elements.
 	}
 
 	polyRegSeries := &chart.PolynomialRegressionSeries{


### PR DESCRIPTION
It seems that `RandomValuesWithMax` is correct.
https://github.com/wcharczuk/go-chart/blob/9e3a080aa3e7573281cf8d65a55305e1148d857d/seq/random.go#L15