### PR TITLE
Fix Invalid go-chart Import URL

### DIFF
--- a/_examples/custom_stylesheets/main.go
+++ b/_examples/custom_stylesheets/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	"github.com/hashworks/go-chart"
+	"github.com/wcharczuk/go-chart"
 	"log"
 	"net/http"
 )


### PR DESCRIPTION
Simply, should import **wcharczuk**'s not **hashworks**'s.