### PR TITLE
Add Hosting Support for twopoint Example

### DIFF
--- a/_examples/twopoint/main.go
+++ b/_examples/twopoint/main.go
@@ -1,15 +1,12 @@
 package main
 
 import (
-	"bytes"
-	"log"
-	"os"
+	"net/http"
 
-	"github.com/wcharczuk/go-chart"
+	chart "github.com/wcharczuk/go-chart"
 )
 
-func main() {
-
+func drawChart(res http.ResponseWriter, req *http.Request) {
 	var b float64
 	b = 1000
 
@@ -51,18 +48,11 @@ func main() {
 		},
 	}
 
-	buffer := bytes.NewBuffer([]byte{})
-	err := graph.Render(chart.PNG, buffer)
-	if err != nil {
-		log.Fatal(err)
-	}
+	res.Header().Set("Content-Type", "image/png")
+	graph.Render(chart.PNG, res)
+}
 
-	fo, err := os.Create("output.png")
-	if err != nil {
-		panic(err)
-	}
-
-	if _, err := fo.Write(buffer.Bytes()); err != nil {
-		panic(err)
-	}
+func main() {
+	http.HandleFunc("/", drawChart)
+	http.ListenAndServe(":8080", nil)
 }


### PR DESCRIPTION
> # Code Examples
> 
> Actual chart configurations and examples can be found in the `./_examples/` directory. They are web servers, so start them with `go run main.go` then access `http://localhost:8080` to see the output.

As we want to have hosting support for examples, implemented for twopoint example.