### PR TITLE
modify getting YAxisSecondary range

### DIFF
--- a/chart.go
+++ b/chart.go
@@ -276,7 +276,7 @@ func (c Chart) getRanges() (xrange, yrange, yrangeAlt Range) {
 
 	if len(c.YAxisSecondary.Ticks) > 0 {
 		tickMin, tickMax := math.MaxFloat64, -math.MaxFloat64
-		for _, t := range c.YAxis.Ticks {
+		for _, t := range c.YAxisSecondary.Ticks {
 			tickMin = math.Min(tickMin, t.Value)
 			tickMax = math.Max(tickMax, t.Value)
 		}


### PR DESCRIPTION
I tried to assign a custom ticker to the `chart.Chart`'s YAxisSecondary.
However, it did not work anyhow.
So I checked the source code and found that It checked `YAxisSecondary.Ticker` is exist and iterate `YAxis.Ticker`!

And I fixed it.
Request you to check.