### PR TITLE
Ensure that LegendThin uses the provided style

### DIFF
--- a/legend.go
+++ b/legend.go
@@ -179,7 +179,7 @@ func LegendThin(c *Chart, userDefaults ...Style) Renderable {
 			Bottom: legendYMargin + legendBoxHeight,
 		}
 
-		Draw.Box(r, legendBox, legendDefaults)
+		Draw.Box(r, legendBox, legendStyle)
 
 		r.SetFont(legendStyle.GetFont())
 		r.SetFontColor(legendStyle.GetFontColor())


### PR DESCRIPTION
Presently LegendThin uses the default style when rendering the box around the legend, this enables callers to customize the box style.