### PR TITLE
Don't output a literal \n in SVG output

### DIFF
--- a/vector_renderer.go
+++ b/vector_renderer.go
@@ -247,7 +247,7 @@ type canvas struct {
 func (c *canvas) Start(width, height int) {
 	c.width = width
 	c.height = height
-	c.w.Write([]byte(fmt.Sprintf(`<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="%d" height="%d">\n`, c.width, c.height)))
+	c.w.Write([]byte(fmt.Sprintf(`<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="%d" height="%d">`+"\n", c.width, c.height)))
 	if c.css != "" {
 		c.w.Write([]byte(`<style type="text/css"`))
 		if c.nonce != "" {


### PR DESCRIPTION
Literal \`...\` strings don't parse escape characters such as \n, so it
would output `<svg [..]\n<path [..] />` instead of an actual newline.