### PR TITLE
Zero data range bar chart now returns custom error

### DIFF
--- a/bar_chart.go
+++ b/bar_chart.go
@@ -2,11 +2,14 @@ package chart
 
 import (
 	"errors"
-	"fmt"
 	"io"
 	"math"
 
 	"github.com/golang/freetype/truetype"
+)
+
+var (
+	ErrZeroDataRange = errors.New("invalid data range; cannot be zero")
 )
 
 // BarChart is a chart that draws bars on a range.
@@ -118,7 +121,7 @@ func (bc BarChart) Render(rp RendererProvider, w io.Writer) error {
 	canvasBox = bc.getDefaultCanvasBox()
 	yr = bc.getRanges()
 	if yr.GetMax()-yr.GetMin() == 0 {
-		return fmt.Errorf("invalid data range; cannot be zero")
+		return ErrZeroDataRange
 	}
 	yr = bc.setRangeDomains(canvasBox, yr)
 	yf = bc.getValueFormatters()

--- a/bar_chart_test.go
+++ b/bar_chart_test.go
@@ -2,6 +2,7 @@ package chart
 
 import (
 	"bytes"
+	"errors"
 	"math"
 	"testing"
 
@@ -43,7 +44,11 @@ func TestBarChartRenderZero(t *testing.T) {
 
 	buf := bytes.NewBuffer([]byte{})
 	err := bc.Render(PNG, buf)
-	testutil.AssertNotNil(t, err)
+	if err != nil {
+		if !errors.Is(err, ErrZeroDataRange) {
+			t.Errorf("assertion failed; expected %v to equal %v", err, ErrZeroDataRange)
+		}
+	}
 }
 
 func TestBarChartProps(t *testing.T) {


### PR DESCRIPTION
Previously, in the case of no range between the data values for bar charts,
`fmt.Errorf` was called (without format arguments), making the resulting
error difficult to compare by downstream users.  This has been replaced
with a custom error, and its test updated.

The `testutil` package does not appear to have a function allowing
assertion using `errors.Is` and therefore the `errors.Is` check is
performed in the test itself.

If this assertion would be preferred as an extension of the `testutil` package,
I would be happy to make this change.