### PR TITLE
font: initialize default font once

### DIFF
--- a/font.go
+++ b/font.go
@@ -7,23 +7,22 @@ import (
 	"github.com/wcharczuk/go-chart/v2/roboto"
 )
 
-var (
-	_defaultFontLock sync.Mutex
-	_defaultFont     *truetype.Font
-)
+var _defaultFont defaultFont
 
 // GetDefaultFont returns the default font (Roboto-Medium).
 func GetDefaultFont() (*truetype.Font, error) {
-	if _defaultFont == nil {
-		_defaultFontLock.Lock()
-		defer _defaultFontLock.Unlock()
-		if _defaultFont == nil {
-			font, err := truetype.Parse(roboto.Roboto)
-			if err != nil {
-				return nil, err
-			}
-			_defaultFont = font
-		}
-	}
-	return _defaultFont, nil
+	return _defaultFont.Font()
+}
+
+type defaultFont struct {
+	font *truetype.Font
+	err  error
+	once sync.Once
+}
+
+func (df *defaultFont) Font() (*truetype.Font, error) {
+	df.once.Do(func() {
+		df.font, df.err = truetype.Parse(roboto.Roboto)
+	})
+	return df.font, df.err
 }

--- a/font.go
+++ b/font.go
@@ -20,9 +20,12 @@ type defaultFont struct {
 	once sync.Once
 }
 
+var _testingHook = func() {}
+
 func (df *defaultFont) Font() (*truetype.Font, error) {
 	df.once.Do(func() {
 		df.font, df.err = truetype.Parse(roboto.Roboto)
+		_testingHook()
 	})
 	return df.font, df.err
 }

--- a/font_test.go
+++ b/font_test.go
@@ -1,0 +1,42 @@
+package chart
+
+import (
+	"testing"
+
+	"github.com/golang/freetype/truetype"
+)
+
+func TestDefaultFont(t *testing.T) {
+	inits := make(chan struct{}, 2)
+	old := _testingHook
+	_testingHook = func() { inits <- struct{}{} }
+	defer func() { _testingHook = old }()
+
+	type testData struct {
+		font *truetype.Font
+		err  error
+	}
+	calls := make(chan testData, 2)
+	for i := 0; i < cap(calls); i++ {
+		go func() {
+			font, err := GetDefaultFont()
+			calls <- testData{font, err}
+		}()
+	}
+
+	var c []testData
+	for i := 0; i < cap(calls); i++ {
+		c = append(c, <-calls)
+	}
+
+	if c[0].err != nil || c[1].err != nil {
+		t.Error("GetDefaultFont got unexpected error: ", c)
+	}
+	if c[0].font != c[1].font {
+		t.Error("GetDefaultFont got different fonts: ", c)
+	}
+
+	if len(inits) > 1 { // Safe to check since we already have two results.
+		t.Error("GetDefaultFont initialized more than once")
+	}
+}


### PR DESCRIPTION
Before this change parallel first executions of `Render` would fail the `-race`
check. `GOARCH=386` or `amd64` would continue working fine, but `arm` sometimes
would freeze the first invocation (I haven't dug deep enough to obtain traces).

Platforms tested:
- Windows 10
- Linux: crostini (ChromeOS)
- Linux: raspberrypi

```
# crostini
uname -a
Linux penguin 5.4.109-26077-g12746d86825a #1 SMP PREEMPT Mon May 17 21:44:06 PDT 2021 x86_64 GNU/Linux

# raspberry pi
Linux raspberrypi 5.10.17-v7l+ #1414 SMP Fri Apr 30 13:20:47 BST 2021 armv7l GNU/Linux
```
