### PR TITLE
Fix bar chart y label

### DIFF
--- a/_examples/bar_chart/main.go
+++ b/_examples/bar_chart/main.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+
+	"github.com/wcharczuk/go-chart"
+)
+
+func drawChart(res http.ResponseWriter, req *http.Request) {
+	sbc := chart.BarChart{
+		Title:      "Test Bar Chart",
+		TitleStyle: chart.StyleShow(),
+		Background: chart.Style{
+			Padding: chart.Box{
+				Top: 40,
+			},
+		},
+		Height:   512,
+		Width:    -1,
+		BarWidth: 60,
+		XAxis:    chart.StyleShow(),
+		YAxis: chart.YAxis{
+			Style: chart.StyleShow(),
+		},
+		Bars: []chart.Value{
+			{Value: 5.25, Label: "Blue"},
+			{Value: 4.88, Label: "Green"},
+			{Value: 4.74, Label: "Gray"},
+			{Value: 3.22, Label: "Orange"},
+			{Value: 3, Label: "Test"},
+			{Value: 2.27, Label: "??"},
+			{Value: 1, Label: "!!"},
+		},
+	}
+
+	res.Header().Set("Content-Type", "image/png")
+	err := sbc.Render(chart.PNG, res)
+	if err != nil {
+		fmt.Printf("Error rendering chart: %v\n", err)
+	}
+}
+
+func port() string {
+	if len(os.Getenv("PORT")) > 0 {
+		return os.Getenv("PORT")
+	}
+	return "8080"
+}
+
+func main() {
+	listenPort := fmt.Sprintf(":%s", port())
+	fmt.Printf("Listening on %s\n", listenPort)
+	http.HandleFunc("/", drawChart)
+	log.Fatal(http.ListenAndServe(listenPort, nil))
+}

--- a/bar_chart.go
+++ b/bar_chart.go
@@ -60,6 +60,8 @@ func (bc BarChart) GetFont() *truetype.Font {
 func (bc BarChart) GetWidth() int {
 	if bc.Width == 0 {
 		return DefaultChartWidth
+	} else if bc.Width == -1 {
+		return bc.autoWidth()
 	}
 	return bc.Width
 }
@@ -86,6 +88,19 @@ func (bc BarChart) GetBarWidth() int {
 		return DefaultBarWidth
 	}
 	return bc.BarWidth
+}
+
+func (bc BarChart) autoWidth() (totalWidth int) {
+
+	totalWidth = 0
+	barWidth := bc.GetBarWidth()
+	barSpacing := bc.GetBarSpacing()
+
+	for _, _ = range bc.Bars {
+		totalWidth += barWidth + barSpacing
+	}
+
+	return
 }
 
 // Render renders the chart with the given renderer to the given io.Writer.

--- a/bar_chart.go
+++ b/bar_chart.go
@@ -146,7 +146,7 @@ func (bc BarChart) Render(rp RendererProvider, w io.Writer) error {
 	bc.drawCanvas(r, canvasBox)
 	bc.drawBars(r, canvasBox, yr)
 	bc.drawXAxis(r, canvasBox)
-	bc.drawYAxis(r, canvasBox, yr, yt)
+	bc.YAxis.Render(r, canvasBox, yr, bc.styleDefaultsAxes(), yt)
 
 	bc.drawTitle(r)
 	for _, a := range bc.Elements {
@@ -274,37 +274,6 @@ func (bc BarChart) drawXAxis(r Renderer, canvasBox Box) {
 			}
 			cursor += width + spacing
 		}
-	}
-}
-
-func (bc BarChart) drawYAxis(r Renderer, canvasBox Box, yr Range, ticks []Tick) {
-	if !bc.YAxis.Style.Hidden {
-		axisStyle := bc.YAxis.Style.InheritFrom(bc.styleDefaultsAxes())
-		axisStyle.WriteToRenderer(r)
-
-		r.MoveTo(canvasBox.Right, canvasBox.Top)
-		r.LineTo(canvasBox.Right, canvasBox.Bottom)
-		r.Stroke()
-
-		r.MoveTo(canvasBox.Right, canvasBox.Bottom)
-		r.LineTo(canvasBox.Right+DefaultHorizontalTickWidth, canvasBox.Bottom)
-		r.Stroke()
-
-		var ty int
-		var tb Box
-		for _, t := range ticks {
-			ty = canvasBox.Bottom - yr.Translate(t.Value)
-
-			axisStyle.GetStrokeOptions().WriteToRenderer(r)
-			r.MoveTo(canvasBox.Right, ty)
-			r.LineTo(canvasBox.Right+DefaultHorizontalTickWidth, ty)
-			r.Stroke()
-
-			axisStyle.GetTextOptions().WriteToRenderer(r)
-			tb = r.MeasureText(t.Label)
-			Draw.Text(r, t.Label, canvasBox.Right+DefaultYAxisMargin+5, ty+(tb.Height()>>1), axisStyle)
-		}
-
 	}
 }
 

--- a/yaxis.go
+++ b/yaxis.go
@@ -114,10 +114,10 @@ func (ya YAxis) Measure(r Renderer, canvasBox Box, ra Range, defaults Style, tic
 
 		if ya.AxisType == YAxisPrimary {
 			minx = canvasBox.Right
-			maxx = MaxInt(maxx, tx+tb.Width())
+			maxx = MaxInt(maxx, tx+tb.Width()+ya.NameStyle.Padding.Left+ya.NameStyle.Padding.Right)
 		} else if ya.AxisType == YAxisSecondary {
-			minx = MinInt(minx, finalTextX)
-			maxx = MaxInt(maxx, tx)
+			minx = MinInt(minx, finalTextX-ya.NameStyle.Padding.Left)
+			maxx = MaxInt(maxx, tx+ya.NameStyle.Padding.Right)
 		}
 
 		miny = MinInt(miny, ly-tbh2)
@@ -201,9 +201,9 @@ func (ya YAxis) Render(r Renderer, canvasBox Box, ra Range, defaults Style, tick
 
 		var tx int
 		if ya.AxisType == YAxisPrimary {
-			tx = canvasBox.Right + int(sw) + DefaultYAxisMargin + maxTextWidth + DefaultYAxisMargin
+			tx = canvasBox.Right + int(sw) + DefaultYAxisMargin + maxTextWidth + DefaultYAxisMargin + nameStyle.Padding.Left
 		} else if ya.AxisType == YAxisSecondary {
-			tx = canvasBox.Left - (DefaultYAxisMargin + int(sw) + maxTextWidth + DefaultYAxisMargin)
+			tx = canvasBox.Left - (DefaultYAxisMargin + int(sw) + maxTextWidth + DefaultYAxisMargin + nameStyle.Padding.Right)
 		}
 
 		var ty int


### PR DESCRIPTION
This pull request fixes the following issues:
1.  YAxis Label not drawn at all for BarChart.
2. Add support for label padding

Instead of using BarChart.drawYAxis we can use YAxis.Render method.
I am unclear why this was not used in the first place otherwise we have code duplication.

**Please note that this branch contains features of an open [pull request](https://github.com/wcharczuk/go-chart/pull/123). PM me after it is approved so I can make any required changes.**
After the fix we can see the label
![output](https://user-images.githubusercontent.com/23219826/139450919-2cb595e4-2c3a-49ca-a661-7d51c1862a71.png)

code
```
package main

//go:generate go run main.go

import (
	"os"

	"github.com/wcharczuk/go-chart/v2"
)

func main() {
	graph := chart.BarChart{
		Title: "Test Bar Chart",
		Background: chart.Style{
			Padding: chart.Box{
				Top: 40,
			},
		},
		Height:   512,
		BarWidth: 60,
		YAxis: chart.YAxis{
			Name: "Label Y",
			NameStyle: chart.Style{
				FontSize:            14,
				Padding:             chart.NewBox(0, 40, 20, 0),
				TextRotationDegrees: 0,
			},
		},
		Bars: []chart.Value{
			{Value: 5.25, Label: "Blue"},
			{Value: 4.88, Label: "Green"},
			{Value: 4.74, Label: "Gray"},
			{Value: 3.22, Label: "Orange"},
			{Value: 3, Label: "Test"},
			{Value: 2.27, Label: "??"},
			{Value: 1, Label: "!!"},
		},
	}

	f, _ := os.Create("output.png")
	defer f.Close()
	graph.Render(chart.PNG, f)
}
```

