### PR TITLE
Missing Alignment Option For text

### DIFF
--- a/draw.go
+++ b/draw.go
@@ -300,6 +300,8 @@ func (d draw) TextWithin(r Renderer, text string, box Box, style Style) {
 		y = y + (box.Height() >> 1) - (linesBox.Height() >> 1)
 	case TextVerticalAlignMiddleBaseline:
 		y = y + (box.Height() >> 1) - linesBox.Height()
+	case TextVerticalAlignTop:
+		y = y + box.Height()
 	}
 
 	var tx, ty int


### PR DESCRIPTION
I think this was just missed, When we do TextRotationDegrees the text does not align with the bottom of the bar. 
This change seems to fix it.