### PR TITLE
In-memory raster renderer

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2
 jobs:
   build:
-    working_directory: /go/src/github.com/wcharczuk/go-chart
+    working_directory: /go/src/github.com/ebudan/go-chart
     docker:
       - image: circleci/golang:1.15
     steps:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 go-chart
 ========
-[![CircleCI](https://circleci.com/gh/wcharczuk/go-chart.svg?style=svg)](https://circleci.com/gh/wcharczuk/go-chart) [![Go Report Card](https://goreportcard.com/badge/github.com/wcharczuk/go-chart)](https://goreportcard.com/report/github.com/wcharczuk/go-chart)
+[![CircleCI](https://circleci.com/gh/wcharczuk/go-chart.svg?style=svg)](https://circleci.com/gh/wcharczuk/go-chart) [![Go Report Card](https://goreportcard.com/badge/github.com/ebudan/go-chart)](https://goreportcard.com/report/github.com/wcharczuk/go-chart)
 
 Package `chart` is a very simple golang native charting library that supports timeseries and continuous line charts.
 
@@ -11,7 +11,7 @@ Master should now be on the v3.x codebase, which overhauls the api significantly
 To install `chart` run the following:
 
 ```bash
-> go get -u github.com/wcharczuk/go-chart
+> go get -u github.com/ebudan/go-chart
 ```
 
 Most of the components are interchangeable so feel free to crib whatever you want.
@@ -58,7 +58,7 @@ import (
     ...
     "bytes"
     ...
-    "github.com/wcharczuk/go-chart" //exposes "chart"
+    "github.com/ebudan/go-chart" //exposes "chart"
 )
 
 graph := chart.Chart{

--- a/_examples/horizontal_stacked_bar/main.go
+++ b/_examples/horizontal_stacked_bar/main.go
@@ -3,8 +3,8 @@ package main
 import (
 	"os"
 
-	"github.com/wcharczuk/go-chart/v2"
-	"github.com/wcharczuk/go-chart/v2/drawing"
+	"github.com/ebudan/go-chart/v2"
+	"github.com/ebudan/go-chart/v2/drawing"
 )
 
 func main() {

--- a/_examples/stacked_bar_labels/main.go
+++ b/_examples/stacked_bar_labels/main.go
@@ -3,8 +3,8 @@ package main
 import (
 	"os"
 
-	"github.com/wcharczuk/go-chart/v2"
-	"github.com/wcharczuk/go-chart/v2/drawing"
+	"github.com/ebudan/go-chart/v2"
+	"github.com/ebudan/go-chart/v2/drawing"
 )
 
 func main() {

--- a/annotation_series_test.go
+++ b/annotation_series_test.go
@@ -4,8 +4,8 @@ import (
 	"image/color"
 	"testing"
 
-	"github.com/wcharczuk/go-chart/v2/drawing"
-	"github.com/wcharczuk/go-chart/v2/testutil"
+	"github.com/ebudan/go-chart/v2/drawing"
+	"github.com/ebudan/go-chart/v2/testutil"
 )
 
 func TestAnnotationSeriesMeasure(t *testing.T) {

--- a/bar_chart_test.go
+++ b/bar_chart_test.go
@@ -5,7 +5,7 @@ import (
 	"math"
 	"testing"
 
-	"github.com/wcharczuk/go-chart/v2/testutil"
+	"github.com/ebudan/go-chart/v2/testutil"
 )
 
 func TestBarChartRender(t *testing.T) {

--- a/bollinger_band_series_test.go
+++ b/bollinger_band_series_test.go
@@ -5,7 +5,7 @@ import (
 	"math"
 	"testing"
 
-	"github.com/wcharczuk/go-chart/v2/testutil"
+	"github.com/ebudan/go-chart/v2/testutil"
 )
 
 func TestBollingerBandSeries(t *testing.T) {

--- a/box_test.go
+++ b/box_test.go
@@ -4,7 +4,7 @@ import (
 	"math"
 	"testing"
 
-	"github.com/wcharczuk/go-chart/v2/testutil"
+	"github.com/ebudan/go-chart/v2/testutil"
 )
 
 func TestBoxClone(t *testing.T) {

--- a/chart_test.go
+++ b/chart_test.go
@@ -8,8 +8,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/wcharczuk/go-chart/v2/drawing"
-	"github.com/wcharczuk/go-chart/v2/testutil"
+	"github.com/ebudan/go-chart/v2/drawing"
+	"github.com/ebudan/go-chart/v2/testutil"
 )
 
 func TestChartGetDPI(t *testing.T) {

--- a/cmd/chart/main.go
+++ b/cmd/chart/main.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/wcharczuk/go-chart/v2"
+	"github.com/ebudan/go-chart/v2"
 )
 
 var (

--- a/colors.go
+++ b/colors.go
@@ -1,6 +1,6 @@
 package chart
 
-import "github.com/wcharczuk/go-chart/v2/drawing"
+import "github.com/ebudan/go-chart/v2/drawing"
 
 var (
 	// ColorWhite is white.

--- a/concat_series_test.go
+++ b/concat_series_test.go
@@ -3,7 +3,7 @@ package chart
 import (
 	"testing"
 
-	"github.com/wcharczuk/go-chart/v2/testutil"
+	"github.com/ebudan/go-chart/v2/testutil"
 )
 
 func TestConcatSeries(t *testing.T) {

--- a/continuous_range_test.go
+++ b/continuous_range_test.go
@@ -3,7 +3,7 @@ package chart
 import (
 	"testing"
 
-	"github.com/wcharczuk/go-chart/v2/testutil"
+	"github.com/ebudan/go-chart/v2/testutil"
 )
 
 func TestRangeTranslate(t *testing.T) {

--- a/continuous_series_test.go
+++ b/continuous_series_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/wcharczuk/go-chart/v2/testutil"
+	"github.com/ebudan/go-chart/v2/testutil"
 )
 
 func TestContinuousSeries(t *testing.T) {

--- a/donut_chart_test.go
+++ b/donut_chart_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/wcharczuk/go-chart/v2/testutil"
+	"github.com/ebudan/go-chart/v2/testutil"
 )
 
 func TestDonutChart(t *testing.T) {

--- a/drawing/color_test.go
+++ b/drawing/color_test.go
@@ -5,7 +5,7 @@ import (
 
 	"image/color"
 
-	"github.com/wcharczuk/go-chart/v2/testutil"
+	"github.com/ebudan/go-chart/v2/testutil"
 )
 
 func TestColorFromHex(t *testing.T) {

--- a/drawing/curve_test.go
+++ b/drawing/curve_test.go
@@ -3,7 +3,7 @@ package drawing
 import (
 	"testing"
 
-	"github.com/wcharczuk/go-chart/v2/testutil"
+	"github.com/ebudan/go-chart/v2/testutil"
 )
 
 type point struct {

--- a/ema_series_test.go
+++ b/ema_series_test.go
@@ -3,7 +3,7 @@ package chart
 import (
 	"testing"
 
-	"github.com/wcharczuk/go-chart/v2/testutil"
+	"github.com/ebudan/go-chart/v2/testutil"
 )
 
 var (

--- a/examples/annotations/main.go
+++ b/examples/annotations/main.go
@@ -5,7 +5,7 @@ package main
 import (
 	"os"
 
-	"github.com/wcharczuk/go-chart/v2"
+	"github.com/ebudan/go-chart/v2"
 )
 
 func main() {

--- a/examples/axes/main.go
+++ b/examples/axes/main.go
@@ -5,7 +5,7 @@ package main
 import (
 	"os"
 
-	chart "github.com/wcharczuk/go-chart/v2"
+	chart "github.com/ebudan/go-chart/v2"
 )
 
 func main() {

--- a/examples/axes_labels/main.go
+++ b/examples/axes_labels/main.go
@@ -5,7 +5,7 @@ package main
 import (
 	"os"
 
-	chart "github.com/wcharczuk/go-chart/v2"
+	chart "github.com/ebudan/go-chart/v2"
 )
 
 func main() {

--- a/examples/bar_chart/main.go
+++ b/examples/bar_chart/main.go
@@ -5,7 +5,7 @@ package main
 import (
 	"os"
 
-	"github.com/wcharczuk/go-chart/v2"
+	"github.com/ebudan/go-chart/v2"
 )
 
 func main() {

--- a/examples/bar_chart_base_value/main.go
+++ b/examples/bar_chart_base_value/main.go
@@ -5,8 +5,8 @@ package main
 import (
 	"os"
 
-	"github.com/wcharczuk/go-chart/v2"
-	"github.com/wcharczuk/go-chart/v2/drawing"
+	"github.com/ebudan/go-chart/v2"
+	"github.com/ebudan/go-chart/v2/drawing"
 )
 
 func main() {

--- a/examples/basic/main.go
+++ b/examples/basic/main.go
@@ -5,7 +5,7 @@ package main
 import (
 	"os"
 
-	"github.com/wcharczuk/go-chart/v2"
+	"github.com/ebudan/go-chart/v2"
 )
 
 func main() {

--- a/examples/benchmark_line_charts/main.go
+++ b/examples/benchmark_line_charts/main.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/wcharczuk/go-chart/v2"
+	"github.com/ebudan/go-chart/v2"
 )
 
 func random(min, max float64) float64 {

--- a/examples/css_classes/main.go
+++ b/examples/css_classes/main.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/wcharczuk/go-chart/v2"
+	"github.com/ebudan/go-chart/v2"
 )
 
 // Note: Additional examples on how to add Stylesheets are in the custom_stylesheets example

--- a/examples/custom_formatters/main.go
+++ b/examples/custom_formatters/main.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/wcharczuk/go-chart/v2"
+	"github.com/ebudan/go-chart/v2"
 )
 
 func main() {

--- a/examples/custom_padding/main.go
+++ b/examples/custom_padding/main.go
@@ -5,8 +5,8 @@ package main
 import (
 	"os"
 
-	"github.com/wcharczuk/go-chart/v2"
-	"github.com/wcharczuk/go-chart/v2/drawing"
+	"github.com/ebudan/go-chart/v2"
+	"github.com/ebudan/go-chart/v2/drawing"
 )
 
 func main() {

--- a/examples/custom_ranges/main.go
+++ b/examples/custom_ranges/main.go
@@ -5,7 +5,7 @@ package main
 import (
 	"os"
 
-	"github.com/wcharczuk/go-chart/v2"
+	"github.com/ebudan/go-chart/v2"
 )
 
 func main() {

--- a/examples/custom_styles/main.go
+++ b/examples/custom_styles/main.go
@@ -5,8 +5,8 @@ package main
 import (
 	"os"
 
-	"github.com/wcharczuk/go-chart/v2"
-	"github.com/wcharczuk/go-chart/v2/drawing"
+	"github.com/ebudan/go-chart/v2"
+	"github.com/ebudan/go-chart/v2/drawing"
 )
 
 func main() {

--- a/examples/custom_stylesheets/main.go
+++ b/examples/custom_stylesheets/main.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/wcharczuk/go-chart/v2"
+	"github.com/ebudan/go-chart/v2"
 )
 
 const style = "svg .background { fill: white; }" +

--- a/examples/custom_ticks/main.go
+++ b/examples/custom_ticks/main.go
@@ -5,7 +5,7 @@ package main
 import (
 	"os"
 
-	"github.com/wcharczuk/go-chart/v2"
+	"github.com/ebudan/go-chart/v2"
 )
 
 func main() {

--- a/examples/descending/main.go
+++ b/examples/descending/main.go
@@ -5,7 +5,7 @@ package main
 import (
 	"os"
 
-	"github.com/wcharczuk/go-chart/v2"
+	"github.com/ebudan/go-chart/v2"
 )
 
 func main() {

--- a/examples/donut_chart/main.go
+++ b/examples/donut_chart/main.go
@@ -5,7 +5,7 @@ package main
 import (
 	"os"
 
-	"github.com/wcharczuk/go-chart/v2"
+	"github.com/ebudan/go-chart/v2"
 )
 
 func main() {

--- a/examples/image_writer/main.go
+++ b/examples/image_writer/main.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/wcharczuk/go-chart/v2"
+	"github.com/ebudan/go-chart/v2"
 )
 
 func main() {

--- a/examples/legend/main.go
+++ b/examples/legend/main.go
@@ -5,7 +5,7 @@ package main
 import (
 	"os"
 
-	chart "github.com/wcharczuk/go-chart/v2"
+	chart "github.com/ebudan/go-chart/v2"
 )
 
 func main() {

--- a/examples/legend_left/main.go
+++ b/examples/legend_left/main.go
@@ -5,7 +5,7 @@ package main
 import (
 	"os"
 
-	"github.com/wcharczuk/go-chart/v2"
+	"github.com/ebudan/go-chart/v2"
 )
 
 func main() {

--- a/examples/linear_regression/main.go
+++ b/examples/linear_regression/main.go
@@ -5,7 +5,7 @@ package main
 import (
 	"os"
 
-	chart "github.com/wcharczuk/go-chart/v2"
+	chart "github.com/ebudan/go-chart/v2"
 )
 
 func main() {

--- a/examples/min_max/main.go
+++ b/examples/min_max/main.go
@@ -5,7 +5,7 @@ package main
 import (
 	"os"
 
-	"github.com/wcharczuk/go-chart/v2"
+	"github.com/ebudan/go-chart/v2"
 )
 
 func main() {

--- a/examples/pie_chart/main.go
+++ b/examples/pie_chart/main.go
@@ -5,7 +5,7 @@ package main
 import (
 	"os"
 
-	"github.com/wcharczuk/go-chart/v2"
+	"github.com/ebudan/go-chart/v2"
 )
 
 func main() {

--- a/examples/poly_regression/main.go
+++ b/examples/poly_regression/main.go
@@ -5,7 +5,7 @@ package main
 import (
 	"os"
 
-	chart "github.com/wcharczuk/go-chart/v2"
+	chart "github.com/ebudan/go-chart/v2"
 )
 
 func main() {

--- a/examples/request_timings/main.go
+++ b/examples/request_timings/main.go
@@ -9,7 +9,7 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/wcharczuk/go-chart/v2"
+	"github.com/ebudan/go-chart/v2"
 )
 
 func main() {

--- a/examples/rerender/main.go
+++ b/examples/rerender/main.go
@@ -6,7 +6,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/wcharczuk/go-chart/v2"
+	"github.com/ebudan/go-chart/v2"
 )
 
 var lock sync.Mutex

--- a/examples/scatter/main.go
+++ b/examples/scatter/main.go
@@ -6,8 +6,8 @@ import (
 
 	_ "net/http/pprof"
 
-	"github.com/wcharczuk/go-chart/v2"
-	"github.com/wcharczuk/go-chart/v2/drawing"
+	"github.com/ebudan/go-chart/v2"
+	"github.com/ebudan/go-chart/v2/drawing"
 )
 
 func drawChart(res http.ResponseWriter, req *http.Request) {

--- a/examples/simple_moving_average/main.go
+++ b/examples/simple_moving_average/main.go
@@ -5,7 +5,7 @@ package main
 import (
 	"os"
 
-	"github.com/wcharczuk/go-chart/v2"
+	"github.com/ebudan/go-chart/v2"
 )
 
 func main() {

--- a/examples/stacked_bar/main.go
+++ b/examples/stacked_bar/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"os"
 
-	"github.com/wcharczuk/go-chart/v2"
+	"github.com/ebudan/go-chart/v2"
 )
 
 func main() {

--- a/examples/stock_analysis/main.go
+++ b/examples/stock_analysis/main.go
@@ -6,8 +6,8 @@ import (
 	"os"
 	"time"
 
-	"github.com/wcharczuk/go-chart/v2"
-	"github.com/wcharczuk/go-chart/v2/drawing"
+	"github.com/ebudan/go-chart/v2"
+	"github.com/ebudan/go-chart/v2/drawing"
 )
 
 func main() {

--- a/examples/text_rotation/main.go
+++ b/examples/text_rotation/main.go
@@ -5,8 +5,8 @@ package main
 import (
 	"os"
 
-	"github.com/wcharczuk/go-chart/v2"
-	"github.com/wcharczuk/go-chart/v2/drawing"
+	"github.com/ebudan/go-chart/v2"
+	"github.com/ebudan/go-chart/v2/drawing"
 )
 
 func main() {

--- a/examples/timeseries/main.go
+++ b/examples/timeseries/main.go
@@ -4,7 +4,7 @@ import (
 	"net/http"
 	"time"
 
-	chart "github.com/wcharczuk/go-chart/v2"
+	chart "github.com/ebudan/go-chart/v2"
 )
 
 func drawChart(res http.ResponseWriter, req *http.Request) {

--- a/examples/twoaxis/main.go
+++ b/examples/twoaxis/main.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/wcharczuk/go-chart/v2"
+	"github.com/ebudan/go-chart/v2"
 )
 
 func main() {

--- a/examples/twopoint/main.go
+++ b/examples/twopoint/main.go
@@ -7,7 +7,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/wcharczuk/go-chart/v2"
+	"github.com/ebudan/go-chart/v2"
 )
 
 func main() {

--- a/first_value_annotation_test.go
+++ b/first_value_annotation_test.go
@@ -3,7 +3,7 @@ package chart
 import (
 	"testing"
 
-	"github.com/wcharczuk/go-chart/v2/testutil"
+	"github.com/ebudan/go-chart/v2/testutil"
 )
 
 func TestFirstValueAnnotation(t *testing.T) {

--- a/font.go
+++ b/font.go
@@ -4,7 +4,7 @@ import (
 	"sync"
 
 	"github.com/golang/freetype/truetype"
-	"github.com/wcharczuk/go-chart/v2/roboto"
+	"github.com/ebudan/go-chart/v2/roboto"
 )
 
 var (

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.15
 
 require (
 	github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0
-	github.com/ebudan/go-chart/v2 v2.1.0 // indirect
 	golang.org/x/image v0.0.0-20200927104501-e162460cd6b5
 )
 

--- a/go.mod
+++ b/go.mod
@@ -4,9 +4,8 @@ go 1.15
 
 require (
 	github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0
-	github.com/wcharczuk/go-chart/v2 v2.1.0
+	github.com/wcharczuk/go-chart/v2 v2.1.0 // indirect
 	golang.org/x/image v0.0.0-20200927104501-e162460cd6b5
 )
 
-// Replacing original's import path to avoid editing all imports here.
 replace github.com/wcharczuk/go-chart/v2 => ./

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,12 @@
-module github.com/wcharczuk/go-chart/v2
+module github.com/ebudan/go-chart/v2
 
 go 1.15
 
 require (
 	github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0
+	github.com/wcharczuk/go-chart/v2 v2.1.0
 	golang.org/x/image v0.0.0-20200927104501-e162460cd6b5
 )
+
+// Replacing original's import path to avoid editing all imports here. 
+replace github.com/wcharczuk/go-chart/v2 => ./

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/ebudan/go-chart
+module github.com/ebudan/go-chart/v2
 
 go 1.15
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/ebudan/go-chart/v2
+module github.com/ebudan/go-chart
 
 go 1.15
 

--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,8 @@ go 1.15
 
 require (
 	github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0
-	github.com/wcharczuk/go-chart/v2 v2.1.0 // indirect
+	github.com/ebudan/go-chart/v2 v2.1.0 // indirect
 	golang.org/x/image v0.0.0-20200927104501-e162460cd6b5
 )
 
-replace github.com/wcharczuk/go-chart/v2 => ./
+replace github.com/ebudan/go-chart/v2 => ./

--- a/go.mod
+++ b/go.mod
@@ -8,5 +8,5 @@ require (
 	golang.org/x/image v0.0.0-20200927104501-e162460cd6b5
 )
 
-// Replacing original's import path to avoid editing all imports here. 
+// Replacing original's import path to avoid editing all imports here.
 replace github.com/wcharczuk/go-chart/v2 => ./

--- a/grid_line_test.go
+++ b/grid_line_test.go
@@ -3,7 +3,7 @@ package chart
 import (
 	"testing"
 
-	"github.com/wcharczuk/go-chart/v2/testutil"
+	"github.com/ebudan/go-chart/v2/testutil"
 )
 
 func TestGenerateGridLines(t *testing.T) {

--- a/histogram_series_test.go
+++ b/histogram_series_test.go
@@ -3,7 +3,7 @@ package chart
 import (
 	"testing"
 
-	"github.com/wcharczuk/go-chart/v2/testutil"
+	"github.com/ebudan/go-chart/v2/testutil"
 )
 
 func TestHistogramSeries(t *testing.T) {

--- a/jet.go
+++ b/jet.go
@@ -1,6 +1,6 @@
 package chart
 
-import "github.com/wcharczuk/go-chart/v2/drawing"
+import "github.com/ebudan/go-chart/v2/drawing"
 
 // Jet is a color map provider based on matlab's jet color map.
 func Jet(v, vmin, vmax float64) drawing.Color {

--- a/last_value_annotation_series_test.go
+++ b/last_value_annotation_series_test.go
@@ -3,7 +3,7 @@ package chart
 import (
 	"testing"
 
-	"github.com/wcharczuk/go-chart/v2/testutil"
+	"github.com/ebudan/go-chart/v2/testutil"
 )
 
 func TestLastValueAnnotationSeries(t *testing.T) {

--- a/legend.go
+++ b/legend.go
@@ -1,7 +1,7 @@
 package chart
 
 import (
-	"github.com/wcharczuk/go-chart/v2/drawing"
+	"github.com/ebudan/go-chart/v2/drawing"
 )
 
 // Legend returns a legend renderable function.

--- a/legend_test.go
+++ b/legend_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/wcharczuk/go-chart/v2/testutil"
+	"github.com/ebudan/go-chart/v2/testutil"
 )
 
 func TestLegend(t *testing.T) {

--- a/linear_regression_series_test.go
+++ b/linear_regression_series_test.go
@@ -3,7 +3,7 @@ package chart
 import (
 	"testing"
 
-	"github.com/wcharczuk/go-chart/v2/testutil"
+	"github.com/ebudan/go-chart/v2/testutil"
 )
 
 func TestLinearRegressionSeries(t *testing.T) {

--- a/macd_series_test.go
+++ b/macd_series_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/wcharczuk/go-chart/v2/testutil"
+	"github.com/ebudan/go-chart/v2/testutil"
 )
 
 var (

--- a/matrix/matrix_test.go
+++ b/matrix/matrix_test.go
@@ -3,7 +3,7 @@ package matrix
 import (
 	"testing"
 
-	"github.com/wcharczuk/go-chart/v2/testutil"
+	"github.com/ebudan/go-chart/v2/testutil"
 )
 
 func TestNew(t *testing.T) {

--- a/matrix/regression_test.go
+++ b/matrix/regression_test.go
@@ -3,7 +3,7 @@ package matrix
 import (
 	"testing"
 
-	"github.com/wcharczuk/go-chart/v2/testutil"
+	"github.com/ebudan/go-chart/v2/testutil"
 )
 
 func TestPoly(t *testing.T) {

--- a/percent_change_series_test.go
+++ b/percent_change_series_test.go
@@ -3,7 +3,7 @@ package chart
 import (
 	"testing"
 
-	"github.com/wcharczuk/go-chart/v2/testutil"
+	"github.com/ebudan/go-chart/v2/testutil"
 )
 
 func TestPercentageDifferenceSeries(t *testing.T) {

--- a/pie_chart_test.go
+++ b/pie_chart_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/wcharczuk/go-chart/v2/testutil"
+	"github.com/ebudan/go-chart/v2/testutil"
 )
 
 func TestPieChart(t *testing.T) {

--- a/polynomial_regression_series.go
+++ b/polynomial_regression_series.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"math"
 
-	"github.com/wcharczuk/go-chart/v2/matrix"
+	"github.com/ebudan/go-chart/v2/matrix"
 )
 
 // Interface Assertions.

--- a/polynomial_regression_test.go
+++ b/polynomial_regression_test.go
@@ -3,8 +3,8 @@ package chart
 import (
 	"testing"
 
-	"github.com/wcharczuk/go-chart/v2/matrix"
-	"github.com/wcharczuk/go-chart/v2/testutil"
+	"github.com/ebudan/go-chart/v2/matrix"
+	"github.com/ebudan/go-chart/v2/testutil"
 )
 
 func TestPolynomialRegression(t *testing.T) {

--- a/raster_renderer.go
+++ b/raster_renderer.go
@@ -23,6 +23,20 @@ func PNG(width, height int) (Renderer, error) {
 	return nil, err
 }
 
+func InMemory(width, height int) (Renderer, error) {
+	i := image.NewRGBA(image.Rect(0, 0, width, height))
+	gc, err := drawing.NewRasterGraphicContext(i)
+	if err == nil {
+		return &memRenderer{
+			rasterRenderer{
+				i:  i,
+				gc: gc,
+			},
+		}, nil
+	}
+	return nil, err
+}
+
 // rasterRenderer renders chart commands to a bitmap.
 type rasterRenderer struct {
 	i  *image.RGBA
@@ -227,4 +241,16 @@ func (rr *rasterRenderer) Save(w io.Writer) error {
 		return nil
 	}
 	return png.Encode(w, rr.i)
+}
+
+type memRenderer struct {
+	rasterRenderer
+}
+
+func (m *memRenderer) Save(w io.Writer) error {
+	return nil
+}
+
+func (m *memRenderer) AsImage() image.Image {
+	return m.i
 }

--- a/raster_renderer.go
+++ b/raster_renderer.go
@@ -7,7 +7,7 @@ import (
 	"math"
 
 	"github.com/golang/freetype/truetype"
-	"github.com/wcharczuk/go-chart/v2/drawing"
+	"github.com/ebudan/go-chart/v2/drawing"
 )
 
 // PNG returns a new png/raster renderer.

--- a/raster_renderer.go
+++ b/raster_renderer.go
@@ -23,6 +23,8 @@ func PNG(width, height int) (Renderer, error) {
 	return nil, err
 }
 
+// InMemory returns an in-memory raster renderer that calls cb() with the
+// rendered image upon completion.
 func InMemory(width, height int, cb func(image.Image)) (Renderer, error) {
 	i := image.NewRGBA(image.Rect(0, 0, width, height))
 	gc, err := drawing.NewRasterGraphicContext(i)

--- a/raster_renderer.go
+++ b/raster_renderer.go
@@ -23,21 +23,30 @@ func PNG(width, height int) (Renderer, error) {
 	return nil, err
 }
 
-// InMemory returns an in-memory raster renderer that calls cb() with the
+// InMemory returns an in-memory raster RenderProvider that calls cb() with the
 // rendered image upon completion.
-func InMemory(width, height int, cb func(image.Image)) (Renderer, error) {
-	i := image.NewRGBA(image.Rect(0, 0, width, height))
-	gc, err := drawing.NewRasterGraphicContext(i)
-	if err == nil {
-		return &memRenderer{
-			rasterRenderer{
-				i:  i,
-				gc: gc,
-			},
-			cb,
-		}, nil
+//
+// Usage suggestion:
+//
+//     ...
+//     chart.Render(chart.InMemory(mycollector.SetImage))
+//     ...
+//
+func InMemory(cb func(image.Image)) RendererProvider {
+	return func(width, height int) (Renderer, error) {
+		i := image.NewRGBA(image.Rect(0, 0, width, height))
+		gc, err := drawing.NewRasterGraphicContext(i)
+		if err == nil {
+			return &memRenderer{
+				rasterRenderer{
+					i:  i,
+					gc: gc,
+				},
+				cb,
+			}, nil
+		}
+		return nil, err
 	}
-	return nil, err
 }
 
 // rasterRenderer renders chart commands to a bitmap.

--- a/raster_renderer.go
+++ b/raster_renderer.go
@@ -23,7 +23,7 @@ func PNG(width, height int) (Renderer, error) {
 	return nil, err
 }
 
-func InMemory(width, height int) (Renderer, error) {
+func InMemory(width, height int, cb func(image.Image)) (Renderer, error) {
 	i := image.NewRGBA(image.Rect(0, 0, width, height))
 	gc, err := drawing.NewRasterGraphicContext(i)
 	if err == nil {
@@ -32,6 +32,7 @@ func InMemory(width, height int) (Renderer, error) {
 				i:  i,
 				gc: gc,
 			},
+			cb,
 		}, nil
 	}
 	return nil, err
@@ -245,12 +246,12 @@ func (rr *rasterRenderer) Save(w io.Writer) error {
 
 type memRenderer struct {
 	rasterRenderer
+	cb func(image.Image)
 }
 
 func (m *memRenderer) Save(w io.Writer) error {
+	if m.cb != nil {
+		m.cb(m.i)
+	}
 	return nil
-}
-
-func (m *memRenderer) AsImage() image.Image {
-	return m.i
 }

--- a/renderer.go
+++ b/renderer.go
@@ -4,7 +4,7 @@ import (
 	"io"
 
 	"github.com/golang/freetype/truetype"
-	"github.com/wcharczuk/go-chart/v2/drawing"
+	"github.com/ebudan/go-chart/v2/drawing"
 )
 
 // Renderer represents the basic methods required to draw a chart.

--- a/seq_test.go
+++ b/seq_test.go
@@ -3,7 +3,7 @@ package chart
 import (
 	"testing"
 
-	"github.com/wcharczuk/go-chart/v2/testutil"
+	"github.com/ebudan/go-chart/v2/testutil"
 )
 
 func TestSeqEach(t *testing.T) {

--- a/sma_series_test.go
+++ b/sma_series_test.go
@@ -3,7 +3,7 @@ package chart
 import (
 	"testing"
 
-	"github.com/wcharczuk/go-chart/v2/testutil"
+	"github.com/ebudan/go-chart/v2/testutil"
 )
 
 type mockValuesProvider struct {

--- a/stringutil_test.go
+++ b/stringutil_test.go
@@ -3,7 +3,7 @@ package chart
 import (
 	"testing"
 
-	"github.com/wcharczuk/go-chart/v2/testutil"
+	"github.com/ebudan/go-chart/v2/testutil"
 )
 
 func TestSplitCSV(t *testing.T) {

--- a/style.go
+++ b/style.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 
 	"github.com/golang/freetype/truetype"
-	"github.com/wcharczuk/go-chart/v2/drawing"
+	"github.com/ebudan/go-chart/v2/drawing"
 )
 
 const (

--- a/style_test.go
+++ b/style_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 
 	"github.com/golang/freetype/truetype"
-	"github.com/wcharczuk/go-chart/v2/drawing"
-	"github.com/wcharczuk/go-chart/v2/testutil"
+	"github.com/ebudan/go-chart/v2/drawing"
+	"github.com/ebudan/go-chart/v2/testutil"
 )
 
 func TestStyleIsZero(t *testing.T) {

--- a/text_test.go
+++ b/text_test.go
@@ -3,7 +3,7 @@ package chart
 import (
 	"testing"
 
-	"github.com/wcharczuk/go-chart/v2/testutil"
+	"github.com/ebudan/go-chart/v2/testutil"
 )
 
 func TestTextWrapWord(t *testing.T) {

--- a/tick_test.go
+++ b/tick_test.go
@@ -3,7 +3,7 @@ package chart
 import (
 	"testing"
 
-	"github.com/wcharczuk/go-chart/v2/testutil"
+	"github.com/ebudan/go-chart/v2/testutil"
 )
 
 func TestGenerateContinuousTicks(t *testing.T) {

--- a/time_series_test.go
+++ b/time_series_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/wcharczuk/go-chart/v2/testutil"
+	"github.com/ebudan/go-chart/v2/testutil"
 )
 
 func TestTimeSeriesGetValue(t *testing.T) {

--- a/value_buffer_test.go
+++ b/value_buffer_test.go
@@ -3,7 +3,7 @@ package chart
 import (
 	"testing"
 
-	"github.com/wcharczuk/go-chart/v2/testutil"
+	"github.com/ebudan/go-chart/v2/testutil"
 )
 
 func TestBuffer(t *testing.T) {

--- a/value_formatter_test.go
+++ b/value_formatter_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/wcharczuk/go-chart/v2/testutil"
+	"github.com/ebudan/go-chart/v2/testutil"
 )
 
 func TestTimeValueFormatterWithFormat(t *testing.T) {

--- a/value_provider.go
+++ b/value_provider.go
@@ -1,6 +1,6 @@
 package chart
 
-import "github.com/wcharczuk/go-chart/v2/drawing"
+import "github.com/ebudan/go-chart/v2/drawing"
 
 // ValuesProvider is a type that produces values.
 type ValuesProvider interface {

--- a/value_test.go
+++ b/value_test.go
@@ -3,7 +3,7 @@ package chart
 import (
 	"testing"
 
-	"github.com/wcharczuk/go-chart/v2/testutil"
+	"github.com/ebudan/go-chart/v2/testutil"
 )
 
 func TestValuesValues(t *testing.T) {

--- a/vector_renderer.go
+++ b/vector_renderer.go
@@ -10,7 +10,7 @@ import (
 	"golang.org/x/image/font"
 
 	"github.com/golang/freetype/truetype"
-	"github.com/wcharczuk/go-chart/v2/drawing"
+	"github.com/ebudan/go-chart/v2/drawing"
 )
 
 // SVG returns a new png/raster renderer.

--- a/vector_renderer_test.go
+++ b/vector_renderer_test.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/wcharczuk/go-chart/v2/drawing"
-	"github.com/wcharczuk/go-chart/v2/testutil"
+	"github.com/ebudan/go-chart/v2/drawing"
+	"github.com/ebudan/go-chart/v2/testutil"
 )
 
 func TestVectorRendererPath(t *testing.T) {

--- a/viridis.go
+++ b/viridis.go
@@ -1,6 +1,6 @@
 package chart
 
-import "github.com/wcharczuk/go-chart/v2/drawing"
+import "github.com/ebudan/go-chart/v2/drawing"
 
 var viridisColors = [256]drawing.Color{
 	drawing.Color{R: 0x44, G: 0x1, B: 0x54, A: 0xff},

--- a/xaxis_test.go
+++ b/xaxis_test.go
@@ -3,7 +3,7 @@ package chart
 import (
 	"testing"
 
-	"github.com/wcharczuk/go-chart/v2/testutil"
+	"github.com/ebudan/go-chart/v2/testutil"
 )
 
 func TestXAxisGetTicks(t *testing.T) {

--- a/yaxis_test.go
+++ b/yaxis_test.go
@@ -3,7 +3,7 @@ package chart
 import (
 	"testing"
 
-	"github.com/wcharczuk/go-chart/v2/testutil"
+	"github.com/ebudan/go-chart/v2/testutil"
 )
 
 func TestYAxisGetTicks(t *testing.T) {


### PR DESCRIPTION
Noticed while testing go-chart in a UI with fairly frequent re-render requirements:
There is no in-memory renderer that would let the user simply acquire an image.Image for display purposes. Using the PNG in raster_renderer.go will incur overhead as it encodes the compressed image.

The simple change request here adds a new utility method (InMemory()), which internally extends the existing rasterRenderer to send the generated image.Image through a callback, rather than serializing to a compressed image format. 

The setup of widgets' Render(RenderProvider, io.Writer) is a bit unwieldy here. I would further suggest splitting the .Save() from the .Render(), either explicitly (requiring the graph creator to call Save()) or perhaps by a similar callback for PNG as I use here with InMemory(). I have not looked too deeply into this yet.
