### PR TITLE
Fix donut chart when there is only one element

### DIFF
--- a/donut_chart.go
+++ b/donut_chart.go
@@ -132,9 +132,16 @@ func (pc DonutChart) drawSlices(r Renderer, canvasBox Box, values []Value) {
 	var lx, ly int
 
 	if len(values) == 1 {
-		pc.styleDonutChartValue(0).WriteToRenderer(r)
+		v := Value{Value: 100, Label: "center"}
+		styletemp := pc.SliceStyle.InheritFrom(Style{
+			StrokeColor: values[0].Style.FillColor, StrokeWidth: 4.0, FillColor: values[0].Style.FillColor, FontColor: values[0].Style.FillColor,
+		})
+		v.Style.InheritFrom(styletemp).WriteToRenderer(r)
 		r.MoveTo(cx, cy)
-		r.Circle(radius, cx, cy)
+		r.ArcTo(cx, cy, (radius / 1.25), (radius / 1.25), DegreesToRadians(0), DegreesToRadians(359))
+		r.LineTo(cx, cy)
+		r.Close()
+		r.FillStroke()
 	} else {
 		for index, v := range values {
 			v.Style.InheritFrom(pc.styleDonutChartValue(index)).WriteToRenderer(r)


### PR DESCRIPTION
When there was only one value for the pie chart the circle was not drawn. 
The style of the value was not used, and the radius of the circle was not matching the value when there are more than one elements.

It seems that "Circle" does not print a correct circle, the shape is weird. To print the donut hole it does not use "Circle", so I used the same code to draw a single element.